### PR TITLE
Update to allow contains method to check text that spans multiple lines

### DIFF
--- a/src/main/java/uk/gov/dvsa/mot/fixtures/mot/AuthenticationStepDefinitions.java
+++ b/src/main/java/uk/gov/dvsa/mot/fixtures/mot/AuthenticationStepDefinitions.java
@@ -270,7 +270,7 @@ public class AuthenticationStepDefinitions implements En {
         driverWrapper.pressButton("Sign in");
 
         // message received after successful login if user has ordered new card, on page with title "Sign in"
-        String orderCardMessage = "You have ordered a new card.  Until you receive and activate the card, "
+        String orderCardMessage = "You have ordered a new card. Until you receive and activate the card, "
                 + "sign in with your security questions.";
 
         // message for when the account is locked

--- a/src/main/java/uk/gov/dvsa/mot/framework/WebDriverWrapper.java
+++ b/src/main/java/uk/gov/dvsa/mot/framework/WebDriverWrapper.java
@@ -1100,7 +1100,7 @@ public class WebDriverWrapper {
      */
     public boolean containsMessage(String message) {
         return webDriver.findElements(
-                By.xpath("//*[text()[contains(.,\"" + expandDataKeys(message) + "\")]]")).size() > 0;
+                By.xpath("//body[contains(normalize-space(.),\"" + expandDataKeys(message) + "\")]")).size() > 0;
     }
 
     /**
@@ -1111,7 +1111,7 @@ public class WebDriverWrapper {
      */
     public boolean doesNotContainMessage(String message) {
         return webDriver.findElements(
-                By.xpath("//*[text()[contains(.,\"" + expandDataKeys(message) + "\")]]")).size() == 0;
+                By.xpath("//body[contains(normalize-space(.),\"" + expandDataKeys(message) + "\")]")).size() == 0;
     }
 
     /**

--- a/src/main/resources/features/theme 1/21 - lost card.feature
+++ b/src/main/resources/features/theme 1/21 - lost card.feature
@@ -25,7 +25,7 @@ Feature: 21 - Existing user has lost 2FA card
     # Login via security questions, activate the new card
     And I load immediately "2FA_CARD_UNUSED" as {serialNumber}
     And I login without 2FA as {username}
-    And The page contains "You have ordered a new card.  Until you receive and activate the card, sign in with your security questions."
+    And The page contains "You have ordered a new card. Until you receive and activate the card, sign in with your security questions."
     And I click the "Continue" link
     And The page title contains "Your security questions"
     And I enter "answer" in the {question1} field
@@ -83,7 +83,7 @@ Feature: 21 - Existing user has lost 2FA card
     # Login via security questions, activate the new card
     And I load immediately "2FA_CARD_UNUSED" as {serialNumber}
     And I login without 2FA as {username}
-    #And The page contains "You have ordered a new card.  Until you receive and activate the card, sign in with your security questions."
+    #And The page contains "You have ordered a new card. Until you receive and activate the card, sign in with your security questions."
     #And I click the "Continue" link
     And The page title contains "Your security questions"
     And I enter "answer" in the {question1} field

--- a/src/test/java/uk/gov/dvsa/mot/framework/WebDriverWrapperTest.java
+++ b/src/test/java/uk/gov/dvsa/mot/framework/WebDriverWrapperTest.java
@@ -1148,6 +1148,8 @@ public class WebDriverWrapperTest {
         assertTrue(driverWrapper.containsMessage("USER023"));
 
         assertTrue(driverWrapper.containsMessage("You have successfully updated the user: Fred Bloggs 'USER023'."));
+
+        assertTrue(driverWrapper.containsMessage("This is a test string on multiple lines here"));
     }
 
     /**

--- a/src/test/java/uk/gov/dvsa/mot/framework/WebDriverWrapperTest.java
+++ b/src/test/java/uk/gov/dvsa/mot/framework/WebDriverWrapperTest.java
@@ -1136,6 +1136,71 @@ public class WebDriverWrapperTest {
     }
 
     /**
+     * Tests <code>containsMessage()</code> can find text ignoring tags.
+     */
+    @Test
+    public void containsMessageIgnoringTags() {
+        browseTo("/containsMessage-5.html", "containsMessage - 5");
+        assertTrue(driverWrapper.containsMessage("You have successfully updated the user:"));
+
+        assertTrue(driverWrapper.containsMessage("Fred Bloggs"));
+
+        assertTrue(driverWrapper.containsMessage("USER023"));
+
+        assertTrue(driverWrapper.containsMessage("You have successfully updated the user: Fred Bloggs 'USER023'."));
+    }
+
+    /**
+     * Tests <code>doesNotContainMessage()</code> should not see tags.
+     */
+    @Test
+    public void doesNotContainMessageIgnoringTags() {
+        browseTo("/containsMessage-5.html", "containsMessage - 5");
+        assertTrue(driverWrapper.doesNotContainMessage("You have successfully updated the user: <strong>Fred Bloggs"
+                + "</strong> 'USER023'."));
+
+        assertTrue(driverWrapper.doesNotContainMessage("You have successfully updated the user: strong Fred Bloggs"
+                + "strong 'USER023'."));
+    }
+
+    /**
+     * Tests <code>containsMessage()</code> can find text over multiple lines.
+     */
+    @Test
+    public void containsMessageOverMultipleLines() {
+        browseTo("/containsMessage-6.html", "containsMessage - 6");
+        assertTrue(driverWrapper.containsMessage("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin "
+                + "blandit nibh maximus nibh mollis luctus. Duis aliquam lacus vitae arcu tincidunt, sit amet laoreet "
+                + "urna rutrum. Pellentesque sed pharetra ex. Phasellus condimentum neque in pharetra pellentesque. "));
+
+        assertTrue(driverWrapper.containsMessage(
+                "Nullam egestas nisl sed mi molestie, nec varius nunc hendrerit. Proin tempus lacus nec cursus "
+                + "mattis. Integer sagittis elit sit amet nisi ultrices, id porta nisi tempus. Maecenas imperdiet nec "
+                + "augue id faucibus. Suspendisse potenti. Pellentesque viverra ante metus, sit amet sollicitudin "
+                + "lectus malesuada a."));
+
+        assertTrue(driverWrapper.containsMessage("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin "
+                + "blandit nibh maximus nibh mollis luctus. Duis aliquam lacus vitae arcu tincidunt, sit amet laoreet "
+                + "urna rutrum. Pellentesque sed pharetra ex. Phasellus condimentum neque in pharetra pellentesque. "
+                + "Nullam egestas nisl sed mi molestie, nec varius nunc hendrerit. Proin tempus lacus nec cursus "
+                + "mattis. Integer sagittis elit sit amet nisi ultrices, id porta nisi tempus. Maecenas imperdiet nec "
+                + "augue id faucibus. Suspendisse potenti. Pellentesque viverra ante metus, sit amet sollicitudin "
+                + "lectus malesuada a."));
+    }
+
+    /**
+     * Tests <code>doesNotContainMessage()</code> can not find text where we add return carriages in the text to check.
+     */
+    @Test
+    public void doesNotContainMessageOverMultipleLines() {
+        browseTo("/containsMessage-6.html", "containsMessage - 6");
+        assertTrue(driverWrapper.doesNotContainMessage("Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                + "Proin blandit nibh maximus nibh mollis luctus.\n"
+                + "Duis aliquam lacus vitae arcu tincidunt, sit amet laoreet urna rutrum. Pellentesque sed pharetra "
+                + "ex."));
+    }
+
+    /**
      * Tests <code>checkTextFromAnyTableRow()</code> with a matching example.
      */
     @Test

--- a/src/test/resources/exampleHtml/containsMessage-5.html
+++ b/src/test/resources/exampleHtml/containsMessage-5.html
@@ -8,6 +8,10 @@
     <p>You have successfully updated the user: <strong>Fred Bloggs</strong> 'USER023'.</p>
   </div>
 
+  <div>
+    <p>This is a test string <br/> on multiple lines <br> here</p>
+  </div>
+
 
 </body>
 </html>

--- a/src/test/resources/exampleHtml/containsMessage-5.html
+++ b/src/test/resources/exampleHtml/containsMessage-5.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>containsMessage - 5</title>
+</head>
+<body>
+
+  <div>
+    <p>You have successfully updated the user: <strong>Fred Bloggs</strong> 'USER023'.</p>
+  </div>
+
+
+</body>
+</html>

--- a/src/test/resources/exampleHtml/containsMessage-6.html
+++ b/src/test/resources/exampleHtml/containsMessage-6.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+  <title>containsMessage - 6</title>
+</head>
+<body>
+
+  <div>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin blandit nibh maximus nibh mollis luctus.
+Duis aliquam lacus vitae arcu tincidunt, sit amet laoreet urna rutrum. Pellentesque sed pharetra ex.
+
+      Phasellus condimentum neque in pharetra pellentesque. Nullam egestas nisl sed mi molestie, nec varius nunc hendrerit.
+
+      Proin tempus lacus nec cursus mattis. Integer sagittis elit sit amet nisi ultrices, id porta nisi tempus.
+          Maecenas imperdiet nec augue id faucibus. Suspendisse potenti. Pellentesque viverra ante metus, sit amet sollicitudin lectus malesuada a.</p>
+  </div>
+
+
+</body>
+</html>


### PR DESCRIPTION
Does this by normalising the html.

It checks the body for and instance of the text after normalising the html. This means that it also ignores html tags between text like <br/>.